### PR TITLE
fix: fix editor menus behaviour

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -117,7 +117,7 @@
             <ul class="edit-tools-list">
               <li class="tool-item transform-tool" id="transform">
                 Transform
-                <ul class="options-list transform-list hidden">
+                <ul class="options-list transform-list hidden" id="transform-list">
                   <li class="edit-option" id="crop">Crop</li>
                   <li class="edit-option" id="resize">Resize</li>
                   <li class="edit-option" id="rotate">Flip and Rotate</li>
@@ -166,7 +166,7 @@
               <li class="tool-item filters-tool" id="filters">
                 Filters
                 <div class="option-controls filter-option-controls">
-                  <div class="filters-controls filters-list hidden">
+                  <div class="filters-controls filters-list hidden" id="filters-list">
                     <div class="filter no-filter selected">
                       <span class="filter-title">No Filter</span>
                     </div>
@@ -202,7 +202,7 @@
               </li>
               <li class="tool-item adjustments-tool" id="adjustments">
                 Adjustments
-                <ul class="options-list adjustments-list hidden">
+                <ul class="options-list adjustments-list hidden" id="adjustments-list">
                   <li class="edit-option" id="blur">Blur</li>
                   <li class="edit-option" id="brigthness">Brightness</li>
                   <li class="edit-option" id="contrast">Contrast</li>

--- a/src/modules/state.ts/editorState-i.ts
+++ b/src/modules/state.ts/editorState-i.ts
@@ -1,0 +1,5 @@
+export interface IStateEditor {
+  selectedTool: Array<HTMLElement | null>;
+  openedList: Array<HTMLElement | null>;
+  openedOption: Array<HTMLElement | null>;
+}

--- a/src/modules/state.ts/editorState.ts
+++ b/src/modules/state.ts/editorState.ts
@@ -1,0 +1,27 @@
+// import { IStateEditor } from './editorState-i';
+
+class State {
+  static tools: { [key: string]: boolean } = {
+    transform: false,
+    filters: false,
+    adjustments: false,
+    text: false,
+    border: false,
+    draw: false,
+  };
+
+  static controls: { [key: string]: boolean } = {
+    crop: false,
+    resize: false,
+    rotate: false,
+    filters: false,
+    adjustments: false,
+  };
+  // static editor: IStateEditor = {
+  //   selectedTool: [],
+  //   openedList: [],
+  //   openedOption: [],
+  // };
+}
+
+export default State;


### PR DESCRIPTION
1) Пофиксила поведение менюшек в редакторе (transform, filters, adjustments):
- теперь одновременно может быть открыто только одно меню/подменю
- если одно открыто, а мы кликаем на второе, то первое закрывается, выделение с него снимается
- если открыта какая-то из опций - например, отрыто меню resize - то при клике на основное меню (transform), меню опции закроется и откроется список всех опций
- добавила класс стейт для состояния менюшек редактора

TODO Vera:
- закрывать все меню при нажатии на Delete Image, Download

![Menu fixed 1](https://user-images.githubusercontent.com/99749026/218345931-2a2ba8b6-1f46-4a88-87a8-93a0ea320221.jpg)

![Menu fixed 2](https://user-images.githubusercontent.com/99749026/218345937-2afbb967-c400-4269-9e58-6b7f55b02d69.jpg)
