### PR TITLE
fix: fix filters name background for readability

### DIFF
--- a/src/style/_optionsControls.scss
+++ b/src/style/_optionsControls.scss
@@ -209,21 +209,10 @@
   display: flex;
   justify-content: center;
   align-items: flex-end;
-  padding-bottom: 4px;
   width: 76px;
   height: 76px;
   border-radius: $border-radius;
 }
-
-// .filter:first-child {
-//   border-top-left-radius: $border-radius;
-//   border-bottom-left-radius: $border-radius;
-// }
-
-// .filter:last-child {
-//   border-top-right-radius: $border-radius;
-//   border-bottom-right-radius: $border-radius;
-// }
 
 .filter:hover {
   border: 2px solid $blue;
@@ -234,8 +223,16 @@
 }
 
 .filter-title {
+  padding-top: 3px;
+  padding-bottom: 3px;
+  width: 100%;
   font-size: 12px;
+  text-align: center;
   color: $white;
+  background-color: $black;
+  border-bottom-left-radius: $border-radius;
+  border-bottom-right-radius: $border-radius;
+  opacity: 0.7;
 }
 //_______________________________________________ADJUSTMENTS
 .adjustments-option-controls {


### PR DESCRIPTION
1) Для контролсов фильтров добавила подложку для названия фильтра, чтобы хорошо читалось и на светлой картинке и на тёмной

![Filters bg0](https://user-images.githubusercontent.com/99749026/218758951-1298db86-35a0-4186-9ff5-d90f7969f9a5.jpg)

![Filters bg1](https://user-images.githubusercontent.com/99749026/218758945-071241bd-c3d1-4214-83c3-67f898603a2c.jpg)

![Filters bg2](https://user-images.githubusercontent.com/99749026/218758949-7f36630b-31b9-40fb-8170-f99ffef05a46.jpg)
